### PR TITLE
Remove `enabled` field from rules

### DIFF
--- a/rules/a_microsoft_teams_member_was_made_owner_of_multiple_teams.yml
+++ b/rules/a_microsoft_teams_member_was_made_owner_of_multiple_teams.yml
@@ -14,7 +14,6 @@ description: |-
       * Investigate activities from the source IP.
       * Examine actions taken by the subject user after being granted owner privileges.
       * Initiate your organization's incident response process.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/a_potentially_malicious_file_was_sent_in_a_microsoft_teams_message.yml
+++ b/rules/a_potentially_malicious_file_was_sent_in_a_microsoft_teams_message.yml
@@ -29,7 +29,6 @@ description: |-
   3. If the user did not intend to send the file or is a guest/external user:
       * Investigate other activities performed by the user.
       * Initiate your organization's incident response process and conduct further investigation.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/consent_given_to_application_associated_with_business_email_compromise_attacks_in_microsoft_365.yml
+++ b/rules/consent_given_to_application_associated_with_business_email_compromise_attacks_in_microsoft_365.yml
@@ -22,7 +22,6 @@ description: |-
   3. If the user is unaware of the application:
       * Investigate other activities performed by the user using the User Investigation dashboard.
       * Begin the incident response process and investigate.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/exchange_online_mail_forwarding_rule_enabled.yml
+++ b/rules/exchange_online_mail_forwarding_rule_enabled.yml
@@ -11,7 +11,6 @@ description: |-
   1. Inspect the forwarding email address to see if it directs emails to an external, non-company owned domain.
   2. Determine if there is a legitimate reason for the mail forwarding rule.
   3. If the user is unaware of the mail forwarding rule, investigate all their accounts for unusual activity.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/microsoft_365_brute_force_login_by_user.yml
+++ b/rules/microsoft_365_brute_force_login_by_user.yml
@@ -3,7 +3,6 @@ name: Microsoft 365 Brute Force Login by User
 description: |-
   Detect potential brute force attacks against Microsoft 365 user
   accounts by monitoring for multiple failed login attempts.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/microsoft_365_ediscovery_content_search_started.yml
+++ b/rules/microsoft_365_ediscovery_content_search_started.yml
@@ -13,7 +13,6 @@ description: |-
   3. If the user is unaware of the content search:
       * Investigate other activities performed by the user.
       * Initiate your organization's incident response process and investigate further.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/microsoft_365_ediscovery_search_export_downloaded.yml
+++ b/rules/microsoft_365_ediscovery_search_export_downloaded.yml
@@ -13,7 +13,6 @@ description: |-
   3. If the user is not aware of the download:
      * Investigate other activities performed by the user.
      * Initiate your organization's incident response process and investigate.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/microsoft_365_exchange_inbox_rule_name_associated_with_business_email_compromise_attacks.yml
+++ b/rules/microsoft_365_exchange_inbox_rule_name_associated_with_business_email_compromise_attacks.yml
@@ -16,7 +16,6 @@ description: |-
   3. If the user is unaware of the inbox rule:
       * Investigate other activities conducted by the user.
       * Initiate the incident response process and investigate further.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/microsoft_365_mail_redirect_via_exchange_transport_rule.yml
+++ b/rules/microsoft_365_mail_redirect_via_exchange_transport_rule.yml
@@ -4,7 +4,6 @@ description: |-
   Detect when Exchange Online transport rules are configured to forward
   or redirect emails, which may indicate data exfiltration or email
   interception attempts.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/microsoft_365_multiple_users_configured_email_forwarding_to_same_destination.yml
+++ b/rules/microsoft_365_multiple_users_configured_email_forwarding_to_same_destination.yml
@@ -4,7 +4,6 @@ description: |-
   Detect when multiple users configure email forwarding to the same
   destination, which may indicate a coordinated attack or data
   exfiltration campaign.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/microsoft_365_onedrive_anonymous_link_created.yml
+++ b/rules/microsoft_365_onedrive_anonymous_link_created.yml
@@ -9,7 +9,6 @@ description: |-
 
   ## Triage and response
   Assess if the document should be accessible anonymously.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/microsoft_365_sharepoint_object_shared_with_guest.yml
+++ b/rules/microsoft_365_sharepoint_object_shared_with_guest.yml
@@ -9,7 +9,6 @@ description: |-
 
   ## Triage and response
   Determine if the document should be shared with the external user.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/microsoft_365_unified_audit_logging_disabled.yml
+++ b/rules/microsoft_365_unified_audit_logging_disabled.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Determine if the user intended to disable audit logging.
   2. If the user is not responsible, investigate them for anomalous activity and, if needed, initiate the incident response process.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/microsoft_365_user_mfa_disabled.yml
+++ b/rules/microsoft_365_user_mfa_disabled.yml
@@ -3,7 +3,6 @@ name: Microsoft 365 User MFA Disabled
 description: |-
   Detect when a user's Multi-Factor Authentication (MFA) has been disabled,
   which can weaken security posture or indicate a potential compromise.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/microsoft_graph_passthrough.yml
+++ b/rules/microsoft_graph_passthrough.yml
@@ -2,7 +2,6 @@
 name: Microsoft Graph Passthrough
 description: |-
   Detect new security alerts from Microsoft Graph Security API.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/microsoft_teams_multiple_teams_deleted.yml
+++ b/rules/microsoft_teams_multiple_teams_deleted.yml
@@ -4,7 +4,6 @@ description: |-
   Detect when multiple teams are deleted within an hour by a single user.
   This can indicate potential data destruction or unauthorized team
   management.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/office_policy_tampering.yml
+++ b/rules/office_policy_tampering.yml
@@ -4,7 +4,6 @@ description: |-
   Detect tampering to Audit Log, Safe Links, Safe Attachment, Anti Phish,
   or data loss prevention (DLP) policies. This may indicate potential
   persistence or defense evasion.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/office_rare_operations.yml
+++ b/rules/office_rare_operations.yml
@@ -4,7 +4,6 @@ description: |-
   Detect Office operations that are typically rare and can provide capabilities
   to attackers. These include mailbox permissions, inbox rules, and transport
   rule modifications.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/office_uploaded_executables.yml
+++ b/rules/office_uploaded_executables.yml
@@ -4,7 +4,6 @@ description: |-
   Detect when executable file types (e.g. `.exe`, `.inf`, `.gzip`,
   `.cmd`, and `.bat`) are uploaded to Office services, such as
   SharePoint and OneDrive.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:microsoft_365

--- a/rules/sharepoint_file_transfers_above_threshold.yml
+++ b/rules/sharepoint_file_transfers_above_threshold.yml
@@ -3,7 +3,6 @@ name: SharePoint File Transfers Above Threshold
 description: |-
   Detect when a large number of SharePoint files or folders are transferred.
   This can indicate potential data exfiltration.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:microsoft_365


### PR DESCRIPTION
Support staging state for out-of-the-box rules. The enabled flag should not take precedence when users add rules with staging state.